### PR TITLE
Неограниченная и быстрая история просмотров

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 # Compiled class file
 *.class
 

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,7 +1,168 @@
+import managers.Managers;
+import managers.TaskManager;
+import tasks.Epic;
+import tasks.Subtask;
+import tasks.Task;
+
+import java.util.*;
+
 public class Main {
+
+    static TaskManager manager = Managers.getDefault();
+    static Random random = new Random();
+    static List<Task> tasks = new ArrayList<>();
+    static Map<Task, Integer> watchingStat = new HashMap<>();
 
     public static void main(String[] args) {
         System.out.println("Поехали!");
+
+        // Создайте две задачи, эпик с тремя подзадачами и эпик без подзадач.
+        createTasks();
+
+        // Запросите созданные задачи несколько раз в разном порядке.
+        for(int i = 0; i < 1000; i++) {
+            Task randomTask = getRandomTask();
+            watch(randomTask);
+            // После каждого запроса выведите историю и убедитесь, что в ней нет повторов.
+            checkHistoryUniqueness();
+        }
+
+        printWatchingStat();
+
+        // Удалите задачу, которая есть в истории, и проверьте, что при печати она не будет выводиться.
+        checkThatDeletedTaskIsRemovedFromHistory();
+
+        // Удалите эпик с тремя подзадачами и убедитесь, что из истории удалился как сам эпик, так и все его подзадачи.
+        checkThatDeletedEpicIsRemovedFromHistoryWithAllItSubtasks();
+
     }
 
+    private static void createTasks() {
+        createAndSaveTask("task1", "desc of task1");
+        createAndSaveTask("task2", "desc of task2");
+        createAndSaveEpicWithSubs("epic1", "desc of epic1", 3);
+        createAndSaveEpicWithSubs("epic2", "desc of epic2", 0);
+    }
+
+    private static void createAndSaveTask(String name, String desc) {
+        Task task = new Task(name, desc);
+        manager.saveTask(task);
+        tasks.add(task);
+    }
+
+    private static void createAndSaveEpicWithSubs(String name, String desc, int subtaskCount) {
+        Epic epic = new Epic(name, desc);
+        manager.saveEpic(epic);
+        tasks.add(epic);
+
+        if (subtaskCount > 0) {
+            for(int i = 0; i < subtaskCount; i++) {
+                Subtask sub = new Subtask("sub " + i + " of " + name, "sub " + i + " desc of " + name,
+                        epic);
+                manager.saveSubtask(sub);
+                tasks.add(sub);
+            }
+        }
+    }
+
+    private static Task getRandomTask() {
+        return tasks.get(random.nextInt(tasks.size()));
+    }
+
+    private static void watch(Task task) {
+        if (task instanceof Epic) {
+            manager.getEpicById(task.getId());
+        } else if (task instanceof Subtask) {
+            manager.getSubtaskById(task.getId());
+        } else {
+            manager.getTaskById(task.getId());
+        }
+        int value = watchingStat.getOrDefault(task, 0);
+        watchingStat.put(task, value + 1);
+    }
+
+    private static void checkHistoryUniqueness() {
+        List<Task> history = manager.getHistory();
+        Set<Task> uniqueHistory = Set.copyOf(history);
+        if (history.size() != uniqueHistory.size()) {
+            throw new RuntimeException(getFailUniquenessMessage(history));
+        }
+    }
+
+    private static String getFailUniquenessMessage(List<Task> history) {
+        Map<Task, Integer> historyStat = new HashMap<>();
+        for(Task task : history) {
+            int count = historyStat.getOrDefault(task, 0);
+            historyStat.put(task, count + 1);
+        }
+        Set<Integer> doubles = new HashSet<>();
+        for(Map.Entry<Task, Integer> entry : historyStat.entrySet()) {
+            if (entry.getValue() > 1) {
+                doubles.add(entry.getKey().getId());
+            }
+        }
+        return String.format("doubles are " + doubles);
+
+    }
+
+    private static void printWatchingStat() {
+        System.out.println("======== WATCHING STATS ===============");
+        for(Map.Entry<Task, Integer> entry : watchingStat.entrySet()) {
+            System.out.println("task \"" + entry.getKey().getName() + "\" has been watched " + entry.getValue() +
+                    " times");
+        }
+        System.out.println("=======================================");
+    }
+
+    private static void checkThatDeletedTaskIsRemovedFromHistory() {
+
+        Task taskToDelete = manager.getTasks().getFirst();
+
+        removeTask(taskToDelete);
+
+        List<Task> history = manager.getHistory();
+        if (history.contains(taskToDelete)) {
+            throw new RuntimeException("задача " + taskToDelete.getName() + " не должна выводится в истории просмотров");
+        } else {
+            System.out.println("задача " + taskToDelete.getName() + " успешно удалилась из истории просмотров");
+        }
+    }
+
+    private static void checkThatDeletedEpicIsRemovedFromHistoryWithAllItSubtasks() {
+        Epic epicToDelete = manager.getEpics()
+                .stream()
+                .filter(e -> !manager.getSubtasksOfEpic(e).isEmpty())
+                .findFirst()
+                .orElseThrow();
+        List<Subtask> subtasks = manager.getSubtasksOfEpic(epicToDelete);
+
+        removeTask(epicToDelete);
+
+        List<Task> history = manager.getHistory();
+        if (history.contains(epicToDelete)) {
+            throw new RuntimeException("эпик \"" + epicToDelete.getName() +
+                    "\" не должен выводится в истории просмотров");
+        } else {
+            System.out.println("эпик \"" + epicToDelete.getName() + "\" успешно удалился из истории просмотров");
+        }
+
+        subtasks.forEach(sub -> {
+            if (history.contains(sub)) {
+                throw new RuntimeException("подзадача \"" + sub.getName() +
+                        "\" не должна выводится в истории просмотров");
+            } else {
+                System.out.println("подзадача \"" + sub.getName() + "\" успешно удалилась из истории просмотров");
+            }
+        });
+    }
+
+    private static void removeTask(Task task) {
+        if (task instanceof Epic) {
+            manager.removeEpicById(task.getId());
+        } else if (task instanceof Subtask) {
+            manager.removeSubtaskById(task.getId());
+        } else {
+            manager.removeTaskById(task.getId());
+        }
+    }
 }

--- a/src/Main.java
+++ b/src/Main.java
@@ -20,7 +20,7 @@ public class Main {
         createTasks();
 
         // Запросите созданные задачи несколько раз в разном порядке.
-        for(int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 1000; i++) {
             Task randomTask = getRandomTask();
             watch(randomTask);
             // После каждого запроса выведите историю и убедитесь, что в ней нет повторов.
@@ -56,7 +56,7 @@ public class Main {
         tasks.add(epic);
 
         if (subtaskCount > 0) {
-            for(int i = 0; i < subtaskCount; i++) {
+            for (int i = 0; i < subtaskCount; i++) {
                 Subtask sub = new Subtask("sub " + i + " of " + name, "sub " + i + " desc of " + name,
                         epic);
                 manager.saveSubtask(sub);
@@ -91,12 +91,12 @@ public class Main {
 
     private static String getFailUniquenessMessage(List<Task> history) {
         Map<Task, Integer> historyStat = new HashMap<>();
-        for(Task task : history) {
+        for (Task task : history) {
             int count = historyStat.getOrDefault(task, 0);
             historyStat.put(task, count + 1);
         }
         Set<Integer> doubles = new HashSet<>();
-        for(Map.Entry<Task, Integer> entry : historyStat.entrySet()) {
+        for (Map.Entry<Task, Integer> entry : historyStat.entrySet()) {
             if (entry.getValue() > 1) {
                 doubles.add(entry.getKey().getId());
             }
@@ -107,7 +107,7 @@ public class Main {
 
     private static void printWatchingStat() {
         System.out.println("======== WATCHING STATS ===============");
-        for(Map.Entry<Task, Integer> entry : watchingStat.entrySet()) {
+        for (Map.Entry<Task, Integer> entry : watchingStat.entrySet()) {
             System.out.println("task \"" + entry.getKey().getName() + "\" has been watched " + entry.getValue() +
                     " times");
         }

--- a/src/managers/HistoryManager.java
+++ b/src/managers/HistoryManager.java
@@ -7,6 +7,8 @@ import java.util.List;
 public interface HistoryManager {
     void add(Task task);
 
+    void remove(int id);
+
     void clear();
 
     List<Task> getHistory();

--- a/src/managers/InMemoryHistoryManager.java
+++ b/src/managers/InMemoryHistoryManager.java
@@ -18,7 +18,7 @@ class InMemoryHistoryManager implements HistoryManager {
     }
 
     @Override
-    public void remove(int id){
+    public void remove(int id) {
         tasks.removeById(id);
     }
 

--- a/src/managers/InMemoryHistoryManager.java
+++ b/src/managers/InMemoryHistoryManager.java
@@ -20,7 +20,7 @@ class InMemoryHistoryManager implements HistoryManager {
     @Override
     public void remove(int id){
         tasks.removeById(id);
-    };
+    }
 
     @Override
     public void clear() {
@@ -35,11 +35,7 @@ class InMemoryHistoryManager implements HistoryManager {
     private static class TaskLinkedList {
         private Node head;
         private Node tail;
-        private Map<Integer, Node> nodeByTaskId = new HashMap<>();
-
-        public int size() {
-            return nodeByTaskId.size();
-        }
+        private final Map<Integer, Node> nodeByTaskId = new HashMap<>();
 
         public void removeById(int id) {
             Node node = nodeByTaskId.get(id);
@@ -49,13 +45,14 @@ class InMemoryHistoryManager implements HistoryManager {
         }
 
         public void clear() {
-            for (Node x = head; x != null; ) {
-                nodeByTaskId.remove(x.item.getId());
-                Node next = x.next;
-                x.item = null;
-                x.next = null;
-                x.prev = null;
-                x = next;
+            Node node = head;
+            while (node != null) {
+                nodeByTaskId.remove(node.item.getId());
+                Node next = node.next;
+                node.item = null;
+                node.next = null;
+                node.prev = null;
+                node = next;
             }
             head = tail = null;
         }
@@ -63,10 +60,10 @@ class InMemoryHistoryManager implements HistoryManager {
         public List<Task> getTasks() {
             List<Task> tasks = new ArrayList<>();
 
-            Node x = head;
-            while (x != null) {
-                tasks.add(x.item);
-                x = x.next;
+            Node node = head;
+            while (node != null) {
+                tasks.add(node.item);
+                node = node.next;
             }
 
             return tasks;
@@ -76,40 +73,40 @@ class InMemoryHistoryManager implements HistoryManager {
 
             removeById(task.getId());
 
-            Node l = tail;
-            Node newNode = new Node(l, task, null);
+            Node oldTail = tail;
+            Node newNode = new Node(oldTail, task, null);
 
             tail = newNode;
-            if (l == null)
+            if (oldTail == null)
                 head = newNode;
             else
-                l.next = newNode;
+                oldTail.next = newNode;
 
             nodeByTaskId.put(task.getId(), newNode);
         }
 
-        void removeNode(Node x) {
-            final Task elem = x.item;
-            final Node next = x.next;
-            final Node prev = x.prev;
+        void removeNode(Node node) {
+            final Task task = node.item;
+            final Node next = node.next;
+            final Node prev = node.prev;
 
-            nodeByTaskId.remove(elem.getId());
+            nodeByTaskId.remove(task.getId());
 
             if (prev == null) {
                 head = next;
             } else {
                 prev.next = next;
-                x.prev = null;
+                node.prev = null;
             }
 
             if (next == null) {
                 tail = prev;
             } else {
                 next.prev = prev;
-                x.next = null;
+                node.next = null;
             }
 
-            x.item = null;
+            node.item = null;
         }
 
         private static class Node {
@@ -119,8 +116,8 @@ class InMemoryHistoryManager implements HistoryManager {
 
             Node(Node prev, Task item, Node next) {
                 this.prev = prev;
-                this.next = next;
                 this.item = item;
+                this.next = next;
             }
         }
     }

--- a/src/managers/InMemoryHistoryManager.java
+++ b/src/managers/InMemoryHistoryManager.java
@@ -60,10 +60,10 @@ class InMemoryHistoryManager implements HistoryManager {
         public List<Task> getTasks() {
             List<Task> tasks = new ArrayList<>();
 
-            Node node = head;
+            Node node = tail;
             while (node != null) {
                 tasks.add(node.item);
-                node = node.next;
+                node = node.prev;
             }
 
             return tasks;

--- a/src/managers/InMemoryHistoryManager.java
+++ b/src/managers/InMemoryHistoryManager.java
@@ -30,6 +30,11 @@ class InMemoryHistoryManager implements HistoryManager {
     }
 
     @Override
+    public void remove(int id){
+        tasks.removeIf(task -> task.getId().equals(id));
+    };
+
+    @Override
     public void clear() {
         tasks.clear();
     }

--- a/src/managers/InMemoryHistoryManager.java
+++ b/src/managers/InMemoryHistoryManager.java
@@ -2,36 +2,24 @@ package managers;
 
 import tasks.Task;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 class InMemoryHistoryManager implements HistoryManager {
 
-    public static final int DEFAULT_MAX_CAPACITY = 10;
-
-    private final int maxCapacity;
-    private final List<Task> tasks;
+    private final TaskLinkedList tasks;
 
     InMemoryHistoryManager() {
-        this(DEFAULT_MAX_CAPACITY);
-    }
-
-    InMemoryHistoryManager(int maxCapacity) {
-        this.maxCapacity = maxCapacity;
-        tasks = new LinkedList<>();
+        tasks = new TaskLinkedList();
     }
 
     @Override
     public synchronized void add(Task task) {
-        if (tasks.size() >= maxCapacity) {
-            tasks.removeFirst();
-        }
-        tasks.addLast(task);
+        tasks.linkLast(task);
     }
 
     @Override
     public void remove(int id){
-        tasks.removeIf(task -> task.getId().equals(id));
+        tasks.removeById(id);
     };
 
     @Override
@@ -41,6 +29,99 @@ class InMemoryHistoryManager implements HistoryManager {
 
     @Override
     public List<Task> getHistory() {
-        return tasks;
+        return tasks.getTasks();
+    }
+
+    private static class TaskLinkedList {
+        private Node head;
+        private Node tail;
+        private Map<Integer, Node> nodeByTaskId = new HashMap<>();
+
+        public int size() {
+            return nodeByTaskId.size();
+        }
+
+        public void removeById(int id) {
+            Node node = nodeByTaskId.get(id);
+            if (node != null) {
+                removeNode(node);
+            }
+        }
+
+        public void clear() {
+            for (Node x = head; x != null; ) {
+                nodeByTaskId.remove(x.item.getId());
+                Node next = x.next;
+                x.item = null;
+                x.next = null;
+                x.prev = null;
+                x = next;
+            }
+            head = tail = null;
+        }
+
+        public List<Task> getTasks() {
+            List<Task> tasks = new ArrayList<>();
+
+            Node x = head;
+            while (x != null) {
+                tasks.add(x.item);
+                x = x.next;
+            }
+
+            return tasks;
+        }
+
+        void linkLast(Task task) {
+
+            removeById(task.getId());
+
+            Node l = tail;
+            Node newNode = new Node(l, task, null);
+
+            tail = newNode;
+            if (l == null)
+                head = newNode;
+            else
+                l.next = newNode;
+
+            nodeByTaskId.put(task.getId(), newNode);
+        }
+
+        void removeNode(Node x) {
+            final Task elem = x.item;
+            final Node next = x.next;
+            final Node prev = x.prev;
+
+            nodeByTaskId.remove(elem.getId());
+
+            if (prev == null) {
+                head = next;
+            } else {
+                prev.next = next;
+                x.prev = null;
+            }
+
+            if (next == null) {
+                tail = prev;
+            } else {
+                next.prev = prev;
+                x.next = null;
+            }
+
+            x.item = null;
+        }
+
+        private static class Node {
+            Node next;
+            Node prev;
+            Task item;
+
+            Node(Node prev, Task item, Node next) {
+                this.prev = prev;
+                this.next = next;
+                this.item = item;
+            }
+        }
     }
 }

--- a/src/managers/InMemoryTaskManager.java
+++ b/src/managers/InMemoryTaskManager.java
@@ -163,7 +163,7 @@ public class InMemoryTaskManager implements TaskManager {
     @Override
     public void updateSubtask(Subtask subtask) {
 
-        if (subtask.getId() == null){
+        if (subtask.getId() == null) {
             System.out.println("Изменить можно только сохраненную подзадачу");
             return;
         }

--- a/src/managers/InMemoryTaskManager.java
+++ b/src/managers/InMemoryTaskManager.java
@@ -190,17 +190,21 @@ public class InMemoryTaskManager implements TaskManager {
     // Удаление
     @Override
     public void removeTasks() {
+        taskRepo.findAll().forEach(task -> historyManager.remove(task.getId()));
         taskRepo.delete();
     }
 
     @Override
     public void removeTaskById(int id) {
+        historyManager.remove(id);
         taskRepo.deleteById(id);
     }
 
     @Override
     public void removeEpics() {
+        subtaskRepo.findAll().forEach(task -> historyManager.remove(task.getId()));
         subtaskRepo.delete();
+        epicRepo.findAll().forEach(task -> historyManager.remove(task.getId()));
         epicRepo.delete();
     }
 
@@ -211,8 +215,10 @@ public class InMemoryTaskManager implements TaskManager {
 
         if (epic != null) {
             for (Integer subtaskId : epic.getSubtasksId()) {
+                historyManager.remove(subtaskId);
                 subtaskRepo.deleteById(subtaskId);
             }
+            historyManager.remove(id);
             epicRepo.deleteById(id);
         }
     }
@@ -220,7 +226,7 @@ public class InMemoryTaskManager implements TaskManager {
     // При удалении подзадач из хранилища также нужно удалить их у эпиков
     @Override
     public void removeSubtasks() {
-
+        subtaskRepo.findAll().forEach(task -> historyManager.remove(task.getId()));
         subtaskRepo.delete();
 
         for (Epic epic : epicRepo.findAll()) {
@@ -237,6 +243,7 @@ public class InMemoryTaskManager implements TaskManager {
         if (subtask != null) {
             Epic epic = getEpicOfSubtask(subtask);
             if (epic != null) {
+                historyManager.remove(id);
                 subtaskRepo.deleteById(id);
                 epic.removeSubtask(subtask);
                 updateEpicStatus(epic);
@@ -267,27 +274,5 @@ public class InMemoryTaskManager implements TaskManager {
     private void updateEpicStatus(Epic epic) {
         List<Subtask> subtasks = getSubtasksOfEpic(epic);
         epic.setStatus(getEpicStatus(subtasks));
-    }
-
-    private boolean areAllSubtasksNew(List<Subtask> subtasks) {
-        return areAllSubtasksHaveStatus(subtasks, TaskStatus.NEW);
-    }
-
-    private boolean areAllSubtasksDone(List<Subtask> subtasks) {
-        return areAllSubtasksHaveStatus(subtasks, TaskStatus.DONE);
-    }
-
-    private boolean areAllSubtasksHaveStatus(List<Subtask> subtasks, TaskStatus taskStatus) {
-        if (subtasks.isEmpty()) {
-            return false;
-        }
-
-        for (Subtask subtask : subtasks) {
-            if (subtask.getStatus() != taskStatus) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/test/managers/InMemoryHistoryManagerTest.java
+++ b/test/managers/InMemoryHistoryManagerTest.java
@@ -32,7 +32,7 @@ class InMemoryHistoryManagerTest {
         history.add(sub);
 
         List<Task> actualTasks = history.getHistory();
-        List<Task> expectedTasks = List.of(task, epic, sub);
+        List<Task> expectedTasks = List.of(sub, epic, task);
         assertIterableEquals(expectedTasks, actualTasks);
     }
 
@@ -43,11 +43,13 @@ class InMemoryHistoryManagerTest {
         List<Task> tasks = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             tasks.add(new Task(i,"task" + i, "desc of task " + i));
+        }
+
+        for (int i = 9; i >= 0; i--) {
             history.add(tasks.get(i));
         }
 
         List<Task> actualTasks = history.getHistory();
-
         assertIterableEquals(tasks, actualTasks);
     }
 
@@ -62,8 +64,8 @@ class InMemoryHistoryManagerTest {
         history.add(task3);
 
         List<Task> actualHistory = history.getHistory();
-        Task actualHistoryTask2 = actualHistory.get(0);
-        Task actualHistoryTask3 = actualHistory.get(1);
+        Task actualHistoryTask3 = actualHistory.get(0);
+        Task actualHistoryTask2 = actualHistory.get(1);
 
         assertEquals(2, actualHistory.size(),
             String.format("history size must be 2, not %s", actualHistory.size()));
@@ -125,6 +127,6 @@ class InMemoryHistoryManagerTest {
 
         history.remove(3);
 
-        assertIterableEquals(List.of(task1, task2), history.getHistory());
+        assertIterableEquals(List.of(task2, task1), history.getHistory());
     }
 }

--- a/test/managers/InMemoryHistoryManagerTest.java
+++ b/test/managers/InMemoryHistoryManagerTest.java
@@ -77,4 +77,59 @@ class InMemoryHistoryManagerTest {
 
         assertEmpty(history.getHistory());
     }
+
+    @Test
+    @DisplayName("Удалить существующую задачу из истории")
+    void removeTaskById() {
+        Task task1 = new Task(1, "task1", "desc1");
+        Task task2 = new Task(2, "task2", "desc2");
+        history.add(task1);
+        history.add(task2);
+
+        history.remove(1);
+
+        assertIterableEquals(List.of(task2), history.getHistory());
+    }
+
+    @Test
+    @DisplayName("Удалить существующую задачу из истории")
+    void givenExistingTask_whenRemove_thenGotTaskRemoved() {
+        Task task1 = new Task(1, "task1", "desc1");
+        Task task2 = new Task(2, "task2", "desc2");
+        history.add(task1);
+        history.add(task2);
+
+        history.remove(1);
+
+        assertIterableEquals(List.of(task2), history.getHistory());
+    }
+
+
+    @Test
+    @DisplayName("Удалить несколько экземпляров существующей задачи")
+    void givenManyTaskWithSameId_whenRemove_thenGotAllRemoved() {
+        Task task1 = new Task(1, "task1", "desc1");
+        Task task2 = new Task(2, "task2", "desc2");
+        Task task3 = new Task(1, "task3", "desc3");
+        history.add(task1);
+        history.add(task2);
+        history.add(task3);
+
+        history.remove(1);
+
+        assertIterableEquals(List.of(task2), history.getHistory());
+    }
+
+    @Test
+    @DisplayName("Удалить несуществующую задачу из истории")
+    void givenNonExistingTask_whenRemove_thenNothingHappens() {
+        Task task1 = new Task(1, "task1", "desc1");
+        Task task2 = new Task(2, "task2", "desc2");
+        history.add(task1);
+        history.add(task2);
+
+        history.remove(3);
+
+        assertIterableEquals(List.of(task1, task2), history.getHistory());
+    }
 }

--- a/test/managers/InMemoryHistoryManagerTest.java
+++ b/test/managers/InMemoryHistoryManagerTest.java
@@ -24,11 +24,11 @@ class InMemoryHistoryManagerTest {
     @Test
     @DisplayName("Добавить три разных задачи")
     void addDifferentTasks() {
-        Task task = new Task("task", "task desc");
+        Task task = new Task(1, "task", "task desc");
         history.add(task);
-        Epic epic = new Epic("epic", "epic desc");
+        Epic epic = new Epic(2, "epic", "epic desc");
         history.add(epic);
-        Subtask sub = new Subtask("sub", "sub desc", epic);
+        Subtask sub = new Subtask(3, "sub", "sub desc", epic);
         history.add(sub);
 
         List<Task> actualTasks = history.getHistory();
@@ -42,7 +42,7 @@ class InMemoryHistoryManagerTest {
 
         List<Task> tasks = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            tasks.add(new Task("task" + i, "desc of task " + i));
+            tasks.add(new Task(i,"task" + i, "desc of task " + i));
             history.add(tasks.get(i));
         }
 
@@ -52,43 +52,38 @@ class InMemoryHistoryManagerTest {
     }
 
     @Test
-    @DisplayName("Добавить одиннадцать задач")
-    void testThatElevenTasksCannotBeAdded() {
+    @DisplayName("Добавить несколько экземпляров существующей задачи")
+    void givenManyTaskWithSameId_whenGetHistory_thenGotLatestTask() {
+        Task task1 = new Task(1, "task1", "desc1");
+        Task task2 = new Task(2, "task2", "desc2");
+        Task task3 = new Task(1, "task3", "desc3");
+        history.add(task1);
+        history.add(task2);
+        history.add(task3);
 
-        List<Task> tasks = new ArrayList<>();
-        for (int i = 0; i < 11; i++) {
-            tasks.add(new Task("task" + i, "desc of task " + i));
-            history.add(tasks.get(i));
-        }
+        List<Task> actualHistory = history.getHistory();
+        Task actualHistoryTask2 = actualHistory.get(0);
+        Task actualHistoryTask3 = actualHistory.get(1);
 
-        List<Task> actualTasks = history.getHistory();
-        List<Task> expectedTasks = tasks.subList(1, 11);
+        assertEquals(2, actualHistory.size(),
+            String.format("history size must be 2, not %s", actualHistory.size()));
 
-        assertIterableEquals(expectedTasks, actualTasks);
+        assertEquals("task2", actualHistoryTask2.getName(),
+            String.format("task2 name must be task2, not %s", actualHistoryTask2.getName()));
+
+        assertEquals("task3", actualHistoryTask3.getName(),
+            String.format("task3 name must be task3, not %s", actualHistoryTask3.getName()));
     }
 
     @Test
-    @DisplayName("Добавить три разных задачи")
+    @DisplayName("Очистить историю")
     void clearHistory() {
-        Task task = new Task("task", "task desc");
+        Task task = new Task(1, "task", "task desc");
         history.add(task);
 
         history.clear();
 
         assertEmpty(history.getHistory());
-    }
-
-    @Test
-    @DisplayName("Удалить существующую задачу из истории")
-    void removeTaskById() {
-        Task task1 = new Task(1, "task1", "desc1");
-        Task task2 = new Task(2, "task2", "desc2");
-        history.add(task1);
-        history.add(task2);
-
-        history.remove(1);
-
-        assertIterableEquals(List.of(task2), history.getHistory());
     }
 
     @Test

--- a/test/managers/InMemoryTaskManagerTest.java
+++ b/test/managers/InMemoryTaskManagerTest.java
@@ -10,6 +10,7 @@ import tasks.Task;
 import tasks.TaskStatus;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -640,11 +641,11 @@ class InMemoryTaskManagerTest {
             Task task = createAndSaveTask("Обычная задача", "Описание обычной задачи");
 
             List<Task> history;
-            List<Task> expectedHistory = new ArrayList<>();
+            List<Task> expectedHistory = new LinkedList<>();
 
             // смотрим обычную задачу
             manager.getTaskById(task.getId());
-            expectedHistory.add(task);
+            expectedHistory.addFirst(task);
 
             history = manager.getHistory();
 
@@ -653,7 +654,7 @@ class InMemoryTaskManagerTest {
 
             // смотрим первую подзадачу
             manager.getSubtaskById(subtask1.getId());
-            expectedHistory.add(subtask1);
+            expectedHistory.addFirst(subtask1);
 
             history = manager.getHistory();
 
@@ -662,7 +663,7 @@ class InMemoryTaskManagerTest {
 
             // смотрим эпик
             manager.getEpicById(epic.getId());
-            expectedHistory.add(epic);
+            expectedHistory.addFirst(epic);
 
             history = manager.getHistory();
 
@@ -673,7 +674,7 @@ class InMemoryTaskManagerTest {
             manager.getSubtaskById(subtask2.getId());
             history = manager.getHistory();
 
-            expectedHistory.add(subtask2);
+            expectedHistory.addFirst(subtask2);
 
             assertIterableEquals(expectedHistory, history, String.format(
                 "история должна быть %s, а не %s", expectedHistory, history));
@@ -723,8 +724,8 @@ class InMemoryTaskManagerTest {
 
             List<Task> actualHistory = manager.getHistory();
             assertEquals(2, actualHistory.size());
-            assertEquals(task2, actualHistory.get(0));
-            assertEquals(task1, actualHistory.get(1));
+            assertEquals(task1, actualHistory.get(0));
+            assertEquals(task2, actualHistory.get(1));
         }
 
         @Test

--- a/test/managers/InMemoryTaskManagerTest.java
+++ b/test/managers/InMemoryTaskManagerTest.java
@@ -769,7 +769,7 @@ class InMemoryTaskManagerTest {
         private Epic epic;
 
         @BeforeEach
-        public void setup(){
+        public void setup() {
             epic = new Epic("epic", "desc");
             manager.saveEpic(epic);
         }


### PR DESCRIPTION
Добавлена функциональность по спринту 6:
1. Сделать историю посещений неограниченной по размеру.
2. Избавиться от повторных просмотров в истории. Если какую-либо задачу посещали несколько раз, то в истории должен остаться только её последний просмотр. Предыдущий должен быть удалён.

